### PR TITLE
Use UTF-8 encoding for Weasyprint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'activemodel'
+gem 'pdf-reader'
 gem 'bundler'
 gem 'pry-byebug'
 gem 'rake'

--- a/lib/pixelpress/renderers/weasyprint_renderer.rb
+++ b/lib/pixelpress/renderers/weasyprint_renderer.rb
@@ -2,7 +2,7 @@ class Pixelpress::WeasyPrintRenderer
   def render(input)
     output = Tempfile.new
 
-    system executable_path, input.path, output.path, exception: true
+    system executable_path, "--encoding", "utf-8", input.path, output.path, exception: true
     return output
   end
   

--- a/spec/renderers/weasyprint_renderer_spec.rb
+++ b/spec/renderers/weasyprint_renderer_spec.rb
@@ -3,14 +3,28 @@ require 'spec_helper'
 
 describe Pixelpress::WeasyPrintRenderer do
   let(:renderer) { Pixelpress::WeasyPrintRenderer.new }
-  let (:input) do 
+  let (:input) do
     file = Tempfile.new
-    file.write("<html><body><h1>hello</h1></body></html>")
+    file.write <<~HTML
+      <html>
+        <head>
+          <meta name=author content="Bärbel Garçon">
+        </head>
+        <body>
+          <h1>Hêllo Wörld</h1>
+        </body>
+      </html>
+    HTML
     file.rewind
     file
   end
 
   it "should render html to pdf" do
-    expect(renderer.render(input).read).to start_with("%PDF")
+    reader = PDF::Reader.new(renderer.render(input))
+
+    expect(reader.info[:Author]).to eq("Bärbel Garçon")
+    expect(reader.page_count).to eq(1)
+    page = reader.pages.sole
+    expect(page.text).to eq("Hêllo Wörld")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'rails/generators/named_base'
 require 'generators/pixelpress/printer/printer_generator'
 require 'pathname'
 require 'open3'
+require 'pdf-reader'
 
 RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
It feels like it's 1998, but Weasyprint doesn't seem to use UTF-8 by default?

If I create an HTML file like this:

```html
<html>
  <head>
    <meta name=author content="Bärbel Garçon">
  </head>
  <body>
    <h1>Hêllo Wörld</h1>
  </body>
</html>
```

And run it through weasyprint with:

```sh
weasyprint in.html out.pdf
```

I get this monstrosity:

<img width="820" alt="image" src="https://github.com/nerdgeschoss/pixelpress/assets/2098462/c44b3e91-fec1-4a45-a145-c57ee012952a">

The fix is to use:

```sh
weasyprint --encoding utf-8 in.html out.pdf
```

<img width="820" alt="image" src="https://github.com/nerdgeschoss/pixelpress/assets/2098462/c399895f-c49e-47f0-81ad-222a1021195a">

To also reflect this fix in the test suite, I installed the Gem `pdf-reader` which can extract text and meta information from PDF files. I was able to reproduce the encoding problems with it, and make sure it's fixed now.