### PR TITLE
Add correct previews directory to `autoload_paths`

### DIFF
--- a/lib/generators/pixelpress/printer/templates/initializer.rb
+++ b/lib/generators/pixelpress/printer/templates/initializer.rb
@@ -1,2 +1,2 @@
-Rails.application.config.autoload_paths << Rails.root.join('app', 'printers')
-Rails.application.config.autoload_paths << Rails.root.join('spec', 'printer', 'previews') if Rails.env.development?
+Rails.application.config.autoload_paths << Rails.root.join('app/printers')
+Rails.application.config.autoload_paths << Rails.root.join('spec/printers/previews') if Rails.env.development?

--- a/lib/pixelpress/preview.rb
+++ b/lib/pixelpress/preview.rb
@@ -1,7 +1,7 @@
 module Pixelpress
   class Preview
     def self.all
-      Dir[Rails.root.join('spec', 'printers', 'previews', '**', '*_preview.rb')].map do |file|
+      Dir[Rails.root.join('spec/printers/previews/**/*_preview.rb')].map do |file|
         require_dependency file
         file.split('printers/previews/').last.sub('.rb', '').classify.constantize.new
       end


### PR DESCRIPTION
There is a typo in the path to the `spec/printers/previews` folder. (It was `spec/printer/previews`, without the `s`.) This means that when editing the previews, you'll always have to restart the Rails server, which is a bit annoying.