### PR TITLE
Raise explicit error when WeasyPrint errors

### DIFF
--- a/lib/pixelpress/renderers/weasyprint_renderer.rb
+++ b/lib/pixelpress/renderers/weasyprint_renderer.rb
@@ -1,10 +1,16 @@
 class Pixelpress::WeasyPrintRenderer
   class WeasyPrintInstallationError < StandardError; end
+  class WeasyPrintExecutionError < StandardError; end
 
   def render(input)
     output = Tempfile.new
 
-    system executable_path, "--encoding", "utf-8", input.path, output.path, exception: true
+    success = system(executable_path, "--encoding", "utf-8", input.path, output.path)
+
+    unless success
+      raise WeasyPrintExecutionError.new("WeasyPrint execution failed with exit code #{$?.exitstatus}")
+    end
+
     return output
   end
 

--- a/spec/renderers/weasyprint_renderer_spec.rb
+++ b/spec/renderers/weasyprint_renderer_spec.rb
@@ -37,4 +37,16 @@ describe Pixelpress::WeasyPrintRenderer do
       }.to raise_error(/Unable to locate weasyprint/)
     end
   end
+
+  context "when weasyprint exits with non-zero exit code" do
+    it "reraises a reasonable error" do
+      expect(renderer).to receive(:system) do
+        Kernel.system("exit 1")
+      end
+
+      expect {
+        renderer.render(input)
+      }.to raise_error(Pixelpress::WeasyPrintRenderer::WeasyPrintExecutionError, "WeasyPrint execution failed with exit code 1")
+    end
+  end
 end


### PR DESCRIPTION
At the moment, we let errors like `Command failed with exit 1` or `Command failed with SIGTERM (signal 15)` bubble up as `RuntimeErrors`.

This makes it harder to explicitly catch them (e.g. in Sidekiq Jobs) and retry.

This PR adds a new `WeasyPrintExecutionError` that gets thrown if our execution of the `weasyprint` binary fails.