### PR TITLE
Fix HTML Previews

### DIFF
--- a/lib/pixelpress/document.rb
+++ b/lib/pixelpress/document.rb
@@ -9,7 +9,7 @@ module Pixelpress
     end
 
     def html
-      file.read
+      file.read.html_safe
     end
 
     def pdf


### PR DESCRIPTION
Documents that went through the rendering engine are html safe already (as the content was intentionally escaped/not escaped in the controller when generating the html), therefore the result can be marked as html safe. This allows printer previews to work out of the box and fix the issue that html is displayed instead of the rendered document.